### PR TITLE
fixed pre_grasp and grasp naming error

### DIFF
--- a/src/giskardpy_ros/goals/grasp_with_ft.py
+++ b/src/giskardpy_ros/goals/grasp_with_ft.py
@@ -115,7 +115,7 @@ class GraspWithForceTorqueGoal(Goal):
                                    bar_center=bar_center,
                                    bar_axis=bar_axis,
                                    bar_length=bar_length,
-                                   grasp_axis_offset=grasp_axis_offset,
+                                   grasp_axis_offset=pre_grasp_axis_offset,
                                    handle_link=handle_name)
         pre_grasp.start_condition = self.start_condition
         pre_grasp.end_condition = end_condition_pre_grasp
@@ -166,7 +166,7 @@ class GraspWithForceTorqueGoal(Goal):
                                       bar_center=bar_center,
                                       bar_axis=bar_axis,
                                       bar_length=bar_length,
-                                      grasp_axis_offset=pre_grasp_axis_offset,
+                                      grasp_axis_offset=grasp_axis_offset,
                                       reference_linear_velocity=self.reference_linear_velocity,
                                       reference_angular_velocity=self.reference_angular_velocity,
                                       handle_link=handle_name)

--- a/src/giskardpy_ros/python_interface/python_interface.py
+++ b/src/giskardpy_ros/python_interface/python_interface.py
@@ -4490,8 +4490,8 @@ class GiskardWrapper:
                              handle_retract_distance: float,
                              tip_link: str = 'hand_gripper_tool_frame',
                              ref_speed: float = 0.5,
-                             pre_grasp_distance: float = -0.15,
-                             grasp_into_distance: float = 0.2,
+                             grasp_into_distance: float = -0.15,
+                             pre_grasp_distance: float = 0.2,
                              offset_along_handle: float = 0.03,
                              ft_timeout: float = 10.0,
                              camera_link: Optional[str] = None):
@@ -4543,7 +4543,7 @@ class GiskardWrapper:
 
         grasp_push = PointStamped()
         grasp_push.header.frame_id = tip_link
-        grasp_push.point.z = grasp_into_distance - pre_grasp_distance
+        grasp_push.point.z = pre_grasp_distance - grasp_into_distance
 
         js = {
             'head_pan_joint': 0,


### PR DESCRIPTION
had pre_grasp and grasp distances the wrong way around in door opening